### PR TITLE
fix: stop reading nonexistent ServiceCall.target attribute

### DIFF
--- a/custom_components/solplanet/services.py
+++ b/custom_components/solplanet/services.py
@@ -14,8 +14,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _build_target(call: ServiceCall) -> dict:
-    """Merge ServiceCall.target with legacy entity_id/device_id from call.data."""
-    target = dict(call.target)
+    """Extract entity_id/device_id from call.data.
+
+    Home Assistant merges any ``target:`` fields into ``call.data`` before the
+    handler runs; ``ServiceCall`` itself has no ``target`` attribute.
+    """
+    target: dict = {}
     if "entity_id" in call.data:
         target["entity_id"] = call.data["entity_id"]
     if "device_id" in call.data:

--- a/custom_components/solplanet/services.py
+++ b/custom_components/solplanet/services.py
@@ -14,10 +14,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _build_target(call: ServiceCall) -> dict:
-    """Extract entity_id/device_id from call.data.
+    """
+    Extract entity_id/device_id from call.data.
 
-    Home Assistant merges any ``target:`` fields into ``call.data`` before the
-    handler runs; ``ServiceCall`` itself has no ``target`` attribute.
+    Home Assistant merges any `target:` fields into `call.data` before the
+    handler runs; `ServiceCall` itself has no `target` attribute.
     """
     target: dict = {}
     if "entity_id" in call.data:


### PR DESCRIPTION
## Summary

- Fixes #17
- Removes a bogus `call.target` read in `_build_target()` (introduced in 1deeeb5). `homeassistant.core.ServiceCall` has no `target` attribute on any HA version — target data is merged into `call.data` by the service call machinery.
- Before the refactor, the inline blocks had `target = call.target if hasattr(call, 'target') else {}` — the `hasattr` was always False, so only the `call.data` merge ever ran. Dropping the guard broke all six services.
- All six service handlers (`set_schedule_slots`, `clear_schedule`, `set_meter_limit_power`, `set_meter_limit_current`, `set_meter_zero_power`, `disable_meter_power_limit`) currently fail on v0.12.0 with `'ServiceCall' object has no attribute 'target'`.

## Change

```diff
 def _build_target(call: ServiceCall) -> dict:
-    """Merge ServiceCall.target with legacy entity_id/device_id from call.data."""
-    target = dict(call.target)
+    """Extract entity_id/device_id from call.data.
+
+    Home Assistant merges any ``target:`` fields into ``call.data`` before the
+    handler runs; ``ServiceCall`` itself has no ``target`` attribute.
+    """
+    target: dict = {}
     if "entity_id" in call.data:
         target["entity_id"] = call.data["entity_id"]
     if "device_id" in call.data:
         target["device_id"] = call.data["device_id"]
     return target
```

## Test plan

- [ ] Call `solplanet.clear_schedule` with `target.device_id` → succeeds (was failing on v0.12.0)
- [x] Call `solplanet.clear_schedule` with legacy `data.device_id` (no `target:`) → still succeeds
- [ ] Smoke-test the other 5 services on a live inverter with battery + meter