### PR TITLE
Add Import Current Limit sensor

### DIFF
--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -270,6 +270,14 @@ def _create_power_limit_entities_description(
             _power_limit_sensor(
                 isn,
                 data_type,
+                "export_current_limit",
+                mapper=_power_limit_value("maxOutCurr", when=("ctrlType", 0)),
+                unit=UnitOfElectricCurrent.AMPERE,
+                device_class=SensorDeviceClass.CURRENT,
+            ),
+            _power_limit_sensor(
+                isn,
+                data_type,
                 "communication_loss_timeout",
                 path=["lostTime"],
                 unit=UnitOfTime.SECONDS,

--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -271,7 +271,7 @@ def _create_power_limit_entities_description(
                 isn,
                 data_type,
                 "export_current_limit",
-                mapper=_power_limit_value("maxOutCurr", when=("ctrlType", 0)),
+                mapper=_power_limit_value("maxOutCurr", when=("ctrlType", 1)),
                 unit=UnitOfElectricCurrent.AMPERE,
                 device_class=SensorDeviceClass.CURRENT,
             ),

--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -262,6 +262,14 @@ def _create_power_limit_entities_description(
             _power_limit_sensor(
                 isn,
                 data_type,
+                "import_current_limit",
+                mapper=_power_limit_value("maxInCurr", when=("ctrlType", 1)),
+                unit=UnitOfElectricCurrent.AMPERE,
+                device_class=SensorDeviceClass.CURRENT,
+            ),
+            _power_limit_sensor(
+                isn,
+                data_type,
                 "communication_loss_timeout",
                 path=["lostTime"],
                 unit=UnitOfTime.SECONDS,

--- a/custom_components/solplanet/strings.json
+++ b/custom_components/solplanet/strings.json
@@ -236,7 +236,8 @@
       "submeter_energy_imported_total": { "name": "Energy imported total" },
       "submeter_energy_exported_today": { "name": "Energy exported today" },
       "submeter_energy_exported_total": { "name": "Energy exported total" },
-      "import_current_limit": { "name": "Import current limit"}
+      "import_current_limit": { "name": "Import current limit"},
+      "export_current_limit": { "name": "Export current limit"}
     },
     "switch": {
       "inverter_power": { "name": "Power" },

--- a/custom_components/solplanet/strings.json
+++ b/custom_components/solplanet/strings.json
@@ -235,7 +235,8 @@
       "submeter_energy_imported_today": { "name": "Energy imported today" },
       "submeter_energy_imported_total": { "name": "Energy imported total" },
       "submeter_energy_exported_today": { "name": "Energy exported today" },
-      "submeter_energy_exported_total": { "name": "Energy exported total" }
+      "submeter_energy_exported_total": { "name": "Energy exported total" },
+      "import_current_limit": { "name": "Import current limit"}
     },
     "switch": {
       "inverter_power": { "name": "Power" },

--- a/custom_components/solplanet/translations/en.json
+++ b/custom_components/solplanet/translations/en.json
@@ -236,7 +236,8 @@
       "submeter_energy_imported_total": { "name": "Energy imported total" },
       "submeter_energy_exported_today": { "name": "Energy exported today" },
       "submeter_energy_exported_total": { "name": "Energy exported total" },
-      "import_current_limit": { "name": "Import current limit"}
+      "import_current_limit": { "name": "Import current limit"},
+      "export_current_limit": { "name": "Export current limit" }
     },
     "switch": {
       "inverter_power": { "name": "Power" },

--- a/custom_components/solplanet/translations/en.json
+++ b/custom_components/solplanet/translations/en.json
@@ -235,7 +235,8 @@
       "submeter_energy_imported_today": { "name": "Energy imported today" },
       "submeter_energy_imported_total": { "name": "Energy imported total" },
       "submeter_energy_exported_today": { "name": "Energy exported today" },
-      "submeter_energy_exported_total": { "name": "Energy exported total" }
+      "submeter_energy_exported_total": { "name": "Energy exported total" },
+      "import_current_limit": { "name": "Import current limit"}
     },
     "switch": {
       "inverter_power": { "name": "Power" },

--- a/custom_components/solplanet/translations/es.json
+++ b/custom_components/solplanet/translations/es.json
@@ -231,7 +231,8 @@
       "eps_phase_current": { "name": "Corriente fase {phase} EPS" },
       "eps_phase_power": { "name": "Potencia fase {phase} EPS" },
       "eps_phase_reactive_power": { "name": "Potencia reactiva fase {phase} EPS" },
-      "import_current_limit": { "name": "Límite de corriente de importación"}
+      "import_current_limit": { "name": "Límite de corriente de importación"},
+      "export_current_limit": { "name": "Límite de corriente de exportación" }
     },
     "switch": {
       "inverter_power": { "name": "Potencia" },

--- a/custom_components/solplanet/translations/es.json
+++ b/custom_components/solplanet/translations/es.json
@@ -230,7 +230,8 @@
       "eps_phase_voltage": { "name": "Voltaje fase {phase} EPS" },
       "eps_phase_current": { "name": "Corriente fase {phase} EPS" },
       "eps_phase_power": { "name": "Potencia fase {phase} EPS" },
-      "eps_phase_reactive_power": { "name": "Potencia reactiva fase {phase} EPS" }
+      "eps_phase_reactive_power": { "name": "Potencia reactiva fase {phase} EPS" },
+      "import_current_limit": { "name": "Límite de corriente de importación"}
     },
     "switch": {
       "inverter_power": { "name": "Potencia" },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -68,7 +68,7 @@ def test_meter_catalog_covers_v2_submeter_v1_and_limit_modes() -> None:
     """Meter descriptions distinguish V2 main meters, sub-meters and V1 data."""
     coordinator = FakeCoordinator()
     main = sensor.create_meter_entities_description(coordinator, "meter-1")
-    assert len(main) == 19
+    assert len(main) == 21
     limit = next(
         item for item in main if item.unique_id_suffix == "power_limit_control"
     )


### PR DESCRIPTION
Added "Import current limit" sensor to complement the export limit sensors already available.

Import current limit is set via an action already available through the integration, and is confirmed working. It is extremely useful for single-phase homes particularly who want to avoid exceeding their main breaker capacity when charging their battery plus other high-draw items.

Import 'power' limit is not confirmed working - all references to it I've seen refer to it not working - so I have intentionally only created the import 'current' sensor at this stage.